### PR TITLE
fix: use correct link for tutorial in medium post

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The hosted version of this repository is live at [http://anupamdagar.com/GitHub-
 5. Place your image in `Assets` directory present inside `src` directory. Make sure to rename it to `profile.jpg` or else you can edit the filename in `import` statement of `Sidebar.js` Component.
 
 ## Blog Post
-The detailed blog post for the tutorial is at ![medium link here]()
+The detailed blog post for the tutorial is at ![medium link here](https://levelup.gitconnected.com/create-a-portfolio-using-react-and-github-student-developer-pack-955379207855)
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).  
 The Bootstrap template used in this tutorial is [https://github.com/BlackrockDigital/startbootstrap-resume](https://github.com/BlackrockDigital/startbootstrap-resume)


### PR DESCRIPTION
The link to the tutorial was empty